### PR TITLE
Fix: Force mime version v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "async": "^2.0.1",
     "dpd-clientlib": "^0.8.9",
     "ejs": "^2.5.1",
-    "filed": "^0.1.0"
+    "filed": "^0.1.0",
+    "mime": "v1.4.0"
   },
   "bugs": {
     "url": "https://github.com/deployd/dpd-dashboard/issues"


### PR DESCRIPTION
filled package depends on "mime": ">= 1.2.6", but latest version of mime has breaking changes, as per the note on their repo: Version 2 is a breaking change from 1.x. filled didn't make the necessary updates, so deployed is broken because of it. Since deployd doesn't depend on latest version of filled, its safe to force the latest 1.x version of mime as well.

Based on discussion from deployd/deployd#821