### PR TITLE
feat: group resources by type

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -105,7 +105,7 @@ Dashboard.prototype.render = function(ctx) {
     render.bodyHtml = options.bodyHtml;
 
     try {
-      var rendered = layout({context: context, render: render, scripts: options.scripts || [], css: options.css || null});
+      var rendered = layout({context: context, render: render, scripts: options.scripts || [], css: options.css || null, version: require('./package.json').version});
       ctx.res.setHeader('Content-Type', 'text/html; charset=UTF-8');
       ctx.res.end(rendered);
     } catch (ex) {

--- a/dashboard/index.ejs
+++ b/dashboard/index.ejs
@@ -55,25 +55,30 @@
     </div>
 
     <script type="text/html" id="resource-sidebar-template">
-      <% var type = types[resource.type]; %>
-      <% var isCurrent = resource.id === Context.resourceId %>
-      <li <%= isCurrent ? 'class="active"' : '' %>>
-        <a href="/dashboard/<%= resource.id %>" <%= type && type.dashboardPages ? 'class="pages-header"' : '' %>>
-          <i class="icon-white icon-custom <%- resource.type.toLowerCase() %>"></i>&nbsp;
-          <% resource.id.split('/').forEach(function(part, index) { %>
-            <span><%- part %></span>
-            <% if(index !== resource.id.split('/').length - 1) { %>
-              <span class="res-separator"> / </span>
-            <% } %>
-          <% }); %>
-        </a>
-        <a href="#" class="options"><span class="caret"></span></a>
-        <% if (type && type.dashboardPages) { %>
-          <ul class="nav pages type-icons <%= isCurrent ? '' : 'hide' %>">
-            <% type.dashboardPages.forEach(function(p) { %>
-              <li <%- isCurrent && (Context.page || '').toLowerCase() === p.toLowerCase() ? 'class=active' : ''%>  ><a href="/dashboard/<%= resource.id %>/<%= p.toLowerCase() %>/"><i class="icon-white icon-custom <%= p.toLowerCase() %>"></i> <%= p %></a></li>
+      <% if(type) { %>
+        <li class="group-type"><%- type.label || type.type %></span>
+      <% } else { %>
+        <% var type = types[resource.type]; %>
+        <% var isCurrent = resource.id === Context.resourceId %>
+
+        <li class="resource" <%= isCurrent ? 'class="active"' : '' %>>
+          <a href="/dashboard/<%= resource.id %>" <%= type && type.dashboardPages ? 'class="pages-header"' : '' %>>
+            <i class="icon-white icon-custom <%- resource.type.toLowerCase() %>"></i>&nbsp;
+            <% resource.id.split('/').forEach(function(part, index) { %>
+              <span><%- part %></span>
+              <% if(index !== resource.id.split('/').length - 1) { %>
+                <span class="res-separator"> / </span>
+              <% } %>
             <% }); %>
-          </ul>
+          </a>
+          <a href="#" class="options"><span class="caret"></span></a>
+          <% if (type && type.dashboardPages) { %>
+            <ul class="nav pages type-icons <%= isCurrent ? '' : 'hide' %>">
+              <% type.dashboardPages.forEach(function(p) { %>
+                <li <%- isCurrent && (Context.page || '').toLowerCase() === p.toLowerCase() ? 'class=active' : ''%>  ><a href="/dashboard/<%= resource.id %>/<%= p.toLowerCase() %>/"><i class="icon-white icon-custom <%= p.toLowerCase() %>"></i> <%= p %></a></li>
+              <% }); %>
+            </ul>
+          <% } %>
         <% } %>
       </li>
     </script>
@@ -117,9 +122,9 @@
     <script type="text/javascript" src="/dashboard/js/lib/ace/mode-json.js"></script>
     <script type="text/javascript" src="/dashboard/js/lib/prettify.js"></script>
     <script type="text/javascript" src="/dpd.js"></script>
-    <script type="text/javascript" src="/dashboard/js/events.js"></script>
-    <script type="text/javascript" src="/dashboard/js/sidebar.js"></script>
-    <script type="text/javascript" src="/dashboard/js/header.js"></script>
+    <script type="text/javascript" src="/dashboard/js/events.js?<?- version ?>"></script>
+    <script type="text/javascript" src="/dashboard/js/sidebar.js?<?- version ?>"></script>
+    <script type="text/javascript" src="/dashboard/js/header.js?<?- version ?>"></script>
 
     <? if (typeof scripts !== 'undefined') scripts.forEach(function(s) { ?>
 

--- a/dashboard/js/sidebar.js
+++ b/dashboard/js/sidebar.js
@@ -71,37 +71,57 @@ $(document).ready(function() {
         if (a.id < b.id) return -1;
         return 0;
       });
+
+      var resourceTypesList = Object.keys(resourceTypes).map(function(k) {
+        return { label: resourceTypes[k].label || resourceTypes[k].type, resource: resourceTypes[k] };
+      }).sort(function(a, b){
+        if (a.label > b.label) return 1;
+        if (a.label < b.label) return -1;
+        return 0;
+      });
       
       $('#resources-empty').hide();
-      resources.forEach(function(resource) {
-        var $el = $(resourceSidebarTemplate({resource: resource, types: resourceTypes}));
 
-        function showContextMenu(e) {
-          var $options = $el.find('.options')
-            , pos = $options.offset();
-          currentMenuResource = resource;
-          resourceMenu.moveTo(pos.left + $options.width(), pos.top + $options.height()).show();
-          e.preventDefault();
-        }
-
-        $el.find('.pages-header').dblclick(function() {
-          location.href = $(this).attr('href');
-        }).click(function(e) {
-          if (e.which === 2) { return true; }
-          $el.find('.pages').slideToggle(200);
-          return false;
-        });
-
-        $el.find('.options').click(function(e) {
-          showContextMenu(e);
-          return false;
-        });
-        $el.on('contextmenu', function(e) {
-          showContextMenu(e);
-          return false;
-        });
+      resourceTypesList.forEach(function(type) {
+        var $el = $(resourceSidebarTemplate({type: type}));
         $el.appendTo($sidebar);
+          
+        resources.filter(function(resource) {
+          return resource.type == type.resource.type;
+        }).forEach(function(resource) {
+          var $el = $(resourceSidebarTemplate({resource: resource, types: resourceTypes}));
+  
+          function showContextMenu(e) {
+            var $options = $el.find('.options')
+              , pos = $options.offset();
+            currentMenuResource = resource;
+            resourceMenu.moveTo(pos.left + $options.width(), pos.top + $options.height()).show();
+            e.preventDefault();
+          }
+  
+          $el.find('.pages-header').dblclick(function() {
+            location.href = $(this).attr('href');
+          }).click(function(e) {
+            if (e.which === 2) { return true; }
+            $el.find('.pages').slideToggle(200);
+            return false;
+          });
+  
+          $el.find('.options').click(function(e) {
+            showContextMenu(e);
+            return false;
+          });
+          // disable context menu
+          // $el.on('contextmenu', function(e) {
+          //   showContextMenu(e);
+          //   return false;
+          // });
+          $el.appendTo($sidebar);
+        });
+
       });
+
+      
     } else {
       $('#resources-empty').show();
     }

--- a/dashboard/stylesheets/style.css
+++ b/dashboard/stylesheets/style.css
@@ -5827,6 +5827,13 @@ td {
       #pre-resource-sidebar li li i {
         position: relative;
         top: -1px; }
+    #resource-sidebar li.group-type,
+    #pre-resource-sidebar li.group-type {
+      color: white;
+      -webkit-box-shadow: inset 3px 3px 40px rgba(0, 0, 0, 0.37);
+      -moz-box-shadow: inset 3px 3px 40px rgba(0, 0, 0, 0.37);
+      box-shadow: inset 3px 3px 40px rgba(0, 0, 0, 0.37);
+      background-color: #1a1a1a; }
   #resource-sidebar a,
   #pre-resource-sidebar a {
     font-weight: bold;

--- a/dashboard/stylesheets/style.scss
+++ b/dashboard/stylesheets/style.scss
@@ -182,6 +182,12 @@ td {
       margin-left: 14px;
       margin-right: 14px; // text-align: center;
     }
+
+    &.group-type {
+      color: white;
+      @include box-shadow(inset 3px 3px 40px rgba(0, 0, 0, .37));
+      background-color: #1a1a1a;
+    }
   }
   a {
     font-weight: bold;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dpd-dashboard",
   "description": "Dashboard for Deployd",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Deployd Contributors",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR changes how resources are displayed in the sidebar, grouping them by resource type.

Once a project grows, this is really needed in order to keep things organized.

Example:

![image](https://user-images.githubusercontent.com/697707/32512987-64c41946-c401-11e7-8d36-3638c9cd192a.png)

Bumps the package to 1.1.0.